### PR TITLE
Make requirement for ViaSponge correct

### DIFF
--- a/ViaSuite.html
+++ b/ViaSuite.html
@@ -181,7 +181,7 @@
                 <a href="https://hangar.papermc.io/ViaVersion/ViaSponge" class="btn btn-primary">Get ViaSponge</a>
             </div>
             <div class="card-footer">
-                Install on: latest Sponge
+                Install on: Sponge v8+
             </div>
         </div>
     </div>


### PR DESCRIPTION
ViaSponge/ViaVersion's sponge platform minimal version to bootstrap is v8, current versions are v11